### PR TITLE
Add the Azure Boards badge to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,2 @@
+[![Board Status](https://dev.azure.com/antoniopassalacqua/1a561f7e-e209-4215-8f25-36cfbf251d02/1afc36a6-6901-4b07-b58e-bd2abcfc915d/_apis/work/boardbadge/9af2b6c9-9523-47a7-8d46-32f7794fb810)](https://dev.azure.com/antoniopassalacqua/1a561f7e-e209-4215-8f25-36cfbf251d02/_boards/board/t/1afc36a6-6901-4b07-b58e-bd2abcfc915d/Microsoft.RequirementCategory)
 # ToDelete Repository


### PR DESCRIPTION
Add the Azure Boards badge for the board used to track the work for this repository. Fixes [AB#1](https://dev.azure.com/antoniopassalacqua/1a561f7e-e209-4215-8f25-36cfbf251d02/_workitems/edit/1). See the [status badge configuration](https://aka.ms/azureboardsgithub-badge) documentation for more information.